### PR TITLE
Add docstrings to analysis functions

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -6,6 +6,22 @@ import pandas as pd
 EXT_NUM_STATS = ("count", "mean", "std", "min", "25%", "50%", "75%", "max")
 
 def column_profile(df: pd.DataFrame, col: str) -> dict:
+    """Compute summary statistics for a single DataFrame column.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame containing the column to profile.
+    col : str
+        Name of the column to analyze.
+
+    Returns
+    -------
+    dict
+        A mapping of metric names to values such as dtype, missing counts,
+        summary statistics and additional shape metrics when the column is
+        numeric.
+    """
     s = df[col]
     info = {
         "dtype": str(s.dtype),
@@ -28,6 +44,18 @@ def column_profile(df: pd.DataFrame, col: str) -> dict:
     return info
 
 def quick_eda(df: pd.DataFrame) -> dict:
+    """Generate basic exploratory data analysis information for a DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The input data.
+
+    Returns
+    -------
+    dict
+        Row and column counts along with per-column dtypes and null counts.
+    """
     out = {
         "rows": int(len(df)),
         "cols": int(df.shape[1]),


### PR DESCRIPTION
## Summary
- document column_profile to explain metrics produced for a single column
- add quick_eda docstring describing returned dataset metadata

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689751adfb48832b9102bb10f09d705b